### PR TITLE
Update index.asciidoc with accurate thread information

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -108,26 +108,29 @@ sure that at least one of these options is different per Event Hub:
 [id="plugins-{type}s-{plugin}-bp-threads"]
 ====== Set number of threads correctly
 
-By default, the number of threads used to service all event hubs is `16`. And while this
-may be sufficient for most use cases, throughput may be improved by refining this number.
-When servicing a large number of partitions across one or more event hubs, setting a higher
-value may result in improved performance. The maximum number of threads is not strictly bound
-by the total number of partitions being serviced, but setting the value much higher than
-that may mean that some threads are idle.
+By default, the number of threads used to service all event hubs is `16`. And
+while this may be sufficient for most use cases, throughput may be improved by
+refining this number. When servicing a large number of partitions across one or
+more event hubs, setting a higher value may result in improved performance. The
+maximum number of threads is not strictly bound by the total number of
+partitions being serviced, but setting the value much higher than that may mean
+that some threads are idle.
 
-NOTE: The number of threads *must* be greater than or equal to the number of Event hubs plus one.
+NOTE: The number of threads *must* be greater than or equal to the number of Event
+hubs plus one.
 
-NOTE: Threads are currently available only as a global setting across all event hubs in a single `azure_event_hubs`
-input definition. However if your configuration includes multiple `azure_event_hubs` inputs, the threads setting applies
+NOTE: Threads are currently available only as a global setting across all event hubs
+in a single `azure_event_hubs` input definition. However if your configuration
+includes multiple `azure_event_hubs` inputs, the threads setting applies
 independently to each.
 
-**Sample scenarios** 
+**Sample scenarios:**
 
-* Event Hubs = 4. Partitions on each Event Hub = 3.
-Minimum threads is 5 (4 Event Hubs plus one).
-* If you’re collecting activity logs from one event hub instance, 
+*  Event Hubs = 4. Partitions on each Event Hub = 3.
+Minimum threads is 5 (4 Event Hubs plus one). Maximum threads is 13 (4 Event
+Hubs times 3 partitions plus one). 
+* If you're collecting activity logs from only one specified event hub instance,
 then only 2 threads (1 Event Hub plus one) are required.
-
 
 [id="plugins-{type}s-{plugin}-eh_config_models"]
 ==== Configuration models


### PR DESCRIPTION
doc

## Release notes
rn:skip

## What does this PR do?
Updates the information on how many threads to use when pulling from an Azure EventHub using Logstash to match the more helpful information provided by the Beats plugin.

## Why is it important/What is the impact to the user?
Before the documentation did not say how partition count within EventHubs should impact the maximum number of threads to use for processing, now it does.